### PR TITLE
Fixed #! line on sh scripts - the space between #! and the shell name…

### DIFF
--- a/binning.sh
+++ b/binning.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#!/bin/bash
 
 if [ "$SMASH_REF" = "" ] || [ ! -f $SMASH_REF ] ; then
     echo export SMASH_REF variable as fasta file path 1>&2

--- a/index_setup.sh
+++ b/index_setup.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#!/bin/bash
 
 if [ "$SMASH_REF" = "" ] || [ ! -f $SMASH_REF ] ; then
     echo export SMASH_REF variable as fasta file path 1>&2

--- a/smash_mapping.sh
+++ b/smash_mapping.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#!/bin/bash
 
 if [ "$SMASH_REF" = "" ] || [ ! -f $SMASH_REF ] ; then
     echo export SMASH_REF variable as fasta file path 1>&2


### PR DESCRIPTION
… (bash) was causing the echo command to be misbehaving and writing to the files chrom_sizes and sam_header the -e prefix breaking the script
